### PR TITLE
add defaults to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,19 +25,23 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     },
     "./client": {
       "types": "./dist/client.d.mts",
-      "import": "./dist/client.mjs"
+      "import": "./dist/client.mjs",
+      "default": "./dist/client.mjs"
     },
     "./plugins": {
       "types": "./dist/plugins/index.d.mts",
-      "import": "./dist/plugins/index.mjs"
+      "import": "./dist/plugins/index.mjs",
+      "default": "./dist/plugins/index.mjs"
     },
     "./native": {
       "types": "./dist/native.d.mts",
-      "import": "./dist/native.mjs"
+      "import": "./dist/native.mjs",
+      "default": "./dist/native.mjs"
     }
   },
   "main": "./dist/index.mjs",


### PR DESCRIPTION
This fixes the issue found here: [Getting error ERR_PACKAGE_PATH_NOT_EXPORTED in backend
 ](https://github.com/productdevbook/better-auth-capacitor/issues/3 ).
 
 The OP just added a 'module: type' to their package.json, but using nx, it isn't that simple for me. Adding defaults fixes the issue.